### PR TITLE
I've updated the Kotlin version to 2.1.0 to resolve build issues.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.0'
+    ext.kotlin_version = '2.1.0'
     repositories {
         google()
         mavenCentral()
@@ -70,8 +70,8 @@ allprojects {
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
         kotlinOptions {
             jvmTarget = '17'
-            apiVersion = '2.0'
-            languageVersion = '2.0'
+            apiVersion = '2.1'
+            languageVersion = '2.1'
             freeCompilerArgs += [
                 '-Xjvm-default=all',
                 '-Xskip-prerelease-check'

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -21,7 +21,7 @@ pluginManagement {
 plugins {
     id 'dev.flutter.flutter-plugin-loader' version '1.0.0'
     id 'com.android.application' version '8.3.0' apply false
-    id 'org.jetbrains.kotlin.android' version '2.0.0' apply false
+    id 'org.jetbrains.kotlin.android' version '2.1.0' apply false
     id 'com.google.gms.google-services' version '4.4.1' apply false
 }
 


### PR DESCRIPTION
The project was failing to build due to Kotlin metadata incompatibility. Dependencies were compiled with Kotlin 2.1.0, while your project was using an older version.

This change updates the following:
- Kotlin Gradle plugin in `android/settings.gradle` to `2.1.0`.
- `ext.kotlin_version` in `android/build.gradle` to `2.1.0`.
- Kotlin `apiVersion` and `languageVersion` in `android/build.gradle` to `2.1`.

These changes are intended to align your project's Kotlin version with its dependencies. I was not able to verify the build in the automated environment.